### PR TITLE
Update config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -69,7 +69,7 @@ languages = [
 compile_sass = true
 
 # Whether to build a search index to be used later on by a JavaScript library
-build_search_index = true
+build_search_index = false
 
 # A list of glob patterns specifying asset files to ignore when the content
 # directory is processed. Defaults to none, which means that all asset files are


### PR DESCRIPTION
Since the theme does not include any Search features, may as well not build the search index, the site/theme will compile slightly faster too.